### PR TITLE
:bug: fix issues/34

### DIFF
--- a/lib/src/get_regexp.dart
+++ b/lib/src/get_regexp.dart
@@ -16,6 +16,12 @@ var fuzzy = '__${int.parse('fuzzy', radix: 36)}__';
 var ignoreSpace = '__${int.parse('ignorespace', radix: 36)}__';
 
 getRegExp(String search, RegExpOptions options) {
+  if (search == '') {
+    /// 전체 리스트 노출
+    // return RegExp('');
+    /// 빈 리스트 노출
+    return RegExp('\\\$');
+  }
   List<String> frontChars = search.split('');
   String? lastChar = frontChars[frontChars.length - 1];
   String lastCharPattern = '';


### PR DESCRIPTION
issue 34에 남긴 텍스트필드의 empty string이 들어갔을때 생기는 오류 


```
getRegExp(String search, RegExpOptions options) {
  if (search == '') {
    /// 전체 리스트 노출
    // return RegExp('');
    /// 빈 리스트 노출
    return RegExp('\\\$');
  }

... 나머지 코드
```

전체 리스트를 노출하는 경우와 빈 리스트를 노출하는 경우 케이스를 나눠봤습니다.

[https://github.com/jpoh281/flutter_korea_regexp/issues/34](url)